### PR TITLE
✨Feat: 기상청 OpenAPI를 통한 날씨 상태 응답 API 구현

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,9 +1,8 @@
-name: CD with Gradle
+name: CD
 on:
   push:
     branches:
       - main
-      - develop
 
 jobs:
   build:

--- a/src/main/java/com/yfive/gbjs/domain/weather/controller/WeatherController.java
+++ b/src/main/java/com/yfive/gbjs/domain/weather/controller/WeatherController.java
@@ -1,0 +1,33 @@
+package com.yfive.gbjs.domain.weather.controller;
+
+import com.yfive.gbjs.domain.weather.dto.response.WeatherResponse;
+import com.yfive.gbjs.domain.weather.service.WeatherService;
+import com.yfive.gbjs.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/weathers")
+@Tag(name = "날씨", description = "날씨 관리 API (공공데이터 기상청 OpenAPI)")
+public class WeatherController {
+
+  private final WeatherService weatherService;
+
+  @Operation(summary = "좌표 기반 날씨 조회", description = "위도/경도를 기반으로 기상청 단기 예보 응답 반환")
+  @GetMapping
+  public ResponseEntity<ApiResponse<WeatherResponse>> getWeather(
+      @Parameter(description = "경도", example = "128.505832") @RequestParam Double longitude,
+      @Parameter(description = "위도", example = "36.5759985") @RequestParam Double latitude
+  ) {
+    WeatherResponse response = weatherService.getWeather(longitude, latitude);
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
+}

--- a/src/main/java/com/yfive/gbjs/domain/weather/dto/response/WeatherResponse.java
+++ b/src/main/java/com/yfive/gbjs/domain/weather/dto/response/WeatherResponse.java
@@ -1,0 +1,26 @@
+package com.yfive.gbjs.domain.weather.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "WeatherResponse DTO", description = "날씨 응답 반환")
+public class WeatherResponse {
+
+  @Schema(description = "최저 기온", example = "21")
+  private String lowestTemperature; // TMN
+
+  @Schema(description = "최고 기온", example = "32")
+  private String highestTemperature; // TMX
+
+  @Schema(description = "현재 기온", example = "29")
+  private String temperature; // TMP
+
+  @Schema(description = "날씨", example = "맑음")
+  private String weather;
+
+  @Schema(description = "강수 확률", example = "50")
+  private String precipitation; // POP
+}

--- a/src/main/java/com/yfive/gbjs/domain/weather/exception/WeatherErrorStatus.java
+++ b/src/main/java/com/yfive/gbjs/domain/weather/exception/WeatherErrorStatus.java
@@ -1,0 +1,20 @@
+package com.yfive.gbjs.domain.weather.exception;
+
+import com.yfive.gbjs.global.error.exception.model.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum WeatherErrorStatus implements BaseErrorCode {
+
+  EMPTY_RESPONSE("WEATHER001", "날씨 API 응답이 비어있습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+  ITEM_NOT_FOUND("WEATHER002", "날씨 정보가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+  PARSING_ERROR("WEATHER003", "날씨 정보 파싱 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+  API_REQUEST_FAILED("WEATHER004", "날씨 API 요청 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+  private final String code;
+  private final String message;
+  private final HttpStatus status;
+}

--- a/src/main/java/com/yfive/gbjs/domain/weather/service/WeatherService.java
+++ b/src/main/java/com/yfive/gbjs/domain/weather/service/WeatherService.java
@@ -1,0 +1,239 @@
+package com.yfive.gbjs.domain.weather.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yfive.gbjs.domain.weather.dto.response.WeatherResponse;
+import com.yfive.gbjs.domain.weather.exception.WeatherErrorStatus;
+import com.yfive.gbjs.global.error.exception.CustomException;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WeatherService {
+
+  private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
+
+  @Value("${weather.api.key}")
+  private String serviceKey;
+
+  @Value("${weather.api.url}")
+  private String weatherApiUrl;
+
+  private final ObjectMapper objectMapper;
+  private final RestClient restClient;
+
+  @Transactional(readOnly = true)
+  public WeatherResponse getWeather(Double longitude, Double latitude) {
+    // 경도/위도를 기상청 격자 좌표로 변환
+    GridCoord gridCoord = convertToGrid(longitude, latitude);
+
+    // 기준 날짜 및 시간 설정
+    String baseTime = getBaseTime();
+    LocalDate baseDate = LocalDate.now(ZONE_ID);
+
+    if (baseTime.equals("2300")) {
+      LocalTime now = LocalTime.now(ZONE_ID);
+      if (now.isBefore(LocalTime.of(2, 0))) {
+        baseDate = baseDate.minusDays(1);
+      }
+    }
+
+    // 요청 URL 조합
+    UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(weatherApiUrl)
+        .queryParam("serviceKey", serviceKey)
+        .queryParam("pageNo", 1)
+        .queryParam("numOfRows", 100)
+        .queryParam("dataType", "JSON")
+        .queryParam("base_date", baseDate.format(DateTimeFormatter.BASIC_ISO_DATE))
+        .queryParam("base_time", baseTime)
+        .queryParam("nx", gridCoord.getNx())
+        .queryParam("ny", gridCoord.getNy());
+
+    try {
+      String response = restClient.get()
+          .uri(uriBuilder.build(true).toUri())
+          .retrieve()
+          .body(String.class);
+
+      if (response == null || response.isBlank()) {
+        log.warn("날씨 API 응답이 비어있습니다.");
+        throw new CustomException(WeatherErrorStatus.EMPTY_RESPONSE);
+      }
+
+      JsonNode root = objectMapper.readTree(response);
+      JsonNode items = root.path("response").path("body").path("items").path("item");
+
+      if (items.isMissingNode() || !items.isArray() || items.size() == 0) {
+        log.warn("날씨 정보가 존재하지 않습니다.");
+        throw new CustomException(WeatherErrorStatus.ITEM_NOT_FOUND);
+      }
+
+      log.info("날씨 정보 조회 성공: baseDate={}, baseTime={}, nx={}, ny={}",
+          baseDate, baseTime, gridCoord.getNx(), gridCoord.getNy());
+
+      return parseWeather(items);
+
+    } catch (CustomException e) {
+      throw e;
+    } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+      log.error("날씨 JSON 파싱 오류: {}", e.getMessage(), e);
+      throw new CustomException(WeatherErrorStatus.PARSING_ERROR);
+    } catch (Exception e) {
+      log.error("날씨 정보 조회 실패: baseDate={}, baseTime={}, nx={}, ny={}, error={}",
+          baseDate, baseTime, gridCoord.getNx(), gridCoord.getNy(), e.getMessage(), e);
+      throw new CustomException(WeatherErrorStatus.API_REQUEST_FAILED);
+    }
+  }
+
+  /**
+   * 위도, 경도를 기상청 격자 좌표로 변환
+   */
+  private GridCoord convertToGrid(double longitude, double latitude) {
+    double RE = 6371.00877; // Earth radius (km)
+    double GRID = 5.0;      // Grid spacing (km)
+    double SLAT1 = 30.0;    // Projection latitude 1 (degree)
+    double SLAT2 = 60.0;    // Projection latitude 2 (degree)
+    double OLON = 126.0;    // Reference longitude (degree)
+    double OLAT = 38.0;     // Reference latitude (degree)
+    double XO = 43;         // Reference point X coordinate
+    double YO = 136;        // Reference point Y coordinate
+
+    double DEGRAD = Math.PI / 180.0;
+
+    double re = RE / GRID;
+    double slat1 = SLAT1 * DEGRAD;
+    double slat2 = SLAT2 * DEGRAD;
+    double olon = OLON * DEGRAD;
+    double olat = OLAT * DEGRAD;
+
+    double sn = Math.tan(Math.PI * 0.25 + slat2 * 0.5) / Math.tan(Math.PI * 0.25 + slat1 * 0.5);
+    sn = Math.log(Math.cos(slat1) / Math.cos(slat2)) / Math.log(sn);
+
+    double sf = Math.tan(Math.PI * 0.25 + slat1 * 0.5);
+    sf = Math.pow(sf, sn) * Math.cos(slat1) / sn;
+
+    double ro = Math.tan(Math.PI * 0.25 + olat * 0.5);
+    ro = re * sf / Math.pow(ro, sn);
+
+    double ra = Math.tan(Math.PI * 0.25 + latitude * DEGRAD * 0.5);
+    ra = re * sf / Math.pow(ra, sn);
+
+    double theta = longitude * DEGRAD - olon;
+    if (theta > Math.PI) {
+      theta -= 2.0 * Math.PI;
+    }
+    if (theta < -Math.PI) {
+      theta += 2.0 * Math.PI;
+    }
+    theta *= sn;
+
+    int x = (int) Math.floor(ra * Math.sin(theta) + XO + 0.5);
+    int y = (int) Math.floor(ro - ra * Math.cos(theta) + YO + 0.5);
+
+    return new GridCoord(x, y);
+  }
+
+  /**
+   * 기상청 발표 기준시간 계산, 발표 시각은 각 시각 +10분 이후부터 조회 가능
+   */
+  private String getBaseTime() {
+    LocalTime now = LocalTime.now(ZONE_ID);
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HHmm");
+
+    List<String> baseTimes = List.of("2300", "2000", "1700", "1400", "1100", "0800", "0500",
+        "0200");
+
+    for (String base : baseTimes) {
+      LocalTime baseTime = LocalTime.parse(base, formatter).plusMinutes(10);
+      if (now.isAfter(baseTime)) {
+        return base;
+      }
+    }
+
+    return "2300";
+  }
+
+  /**
+   * JSON 응답을 WeatherResponse로 파싱
+   */
+  private WeatherResponse parseWeather(JsonNode items) {
+    String temperature = null;
+    String skyStatus = null;
+    String lowestTemperature = null;
+    String highestTemperature = null;
+    String precipitation = null;
+    String precipitationType = null;
+    String weather;
+
+    for (JsonNode item : items) {
+      String category = item.get("category").asText();
+      String value = item.get("fcstValue").asText();
+
+      switch (category) {
+        case "TMP" -> temperature = value;
+        case "SKY" -> skyStatus = mapSkyStatus(value);
+        case "TMN" -> lowestTemperature = value;
+        case "TMX" -> highestTemperature = value;
+        case "POP" -> precipitation = value;
+        case "PTY" -> precipitationType = mapPrecipitationType(value);
+      }
+    }
+
+    if (Objects.equals(precipitationType, "없음")) {
+      weather = skyStatus;
+    } else {
+      weather = precipitationType;
+    }
+
+    return WeatherResponse.builder()
+        .lowestTemperature(lowestTemperature)
+        .highestTemperature(highestTemperature)
+        .temperature(temperature)
+        .weather(weather)
+        .precipitation(precipitation)
+        .build();
+  }
+
+  private String mapSkyStatus(String code) {
+    return switch (code) {
+      case "1" -> "맑음";
+      case "3" -> "구름많음";
+      case "4" -> "흐림";
+      default -> "알 수 없음";
+    };
+  }
+
+  private String mapPrecipitationType(String code) {
+    return switch (code) {
+      case "0" -> "없음";
+      case "1" -> "비";
+      case "2" -> "비/눈";
+      case "3" -> "눈";
+      case "4" -> "소나기";
+      default -> "알 수 없음";
+    };
+  }
+
+  @Getter
+  @AllArgsConstructor
+  private static class GridCoord {
+
+    private final int nx;
+    private final int ny;
+  }
+}

--- a/src/main/java/com/yfive/gbjs/global/common/response/ResponseCode.java
+++ b/src/main/java/com/yfive/gbjs/global/common/response/ResponseCode.java
@@ -3,10 +3,9 @@
  */
 package com.yfive.gbjs.global.common.response;
 
-import org.springframework.http.HttpStatus;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/com/yfive/gbjs/global/config/RestClientConfig.java
+++ b/src/main/java/com/yfive/gbjs/global/config/RestClientConfig.java
@@ -1,0 +1,14 @@
+package com.yfive.gbjs.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+  @Bean
+  public RestClient restClient(RestClient.Builder builder) {
+    return builder.build();
+  }
+}

--- a/src/main/java/com/yfive/gbjs/global/error/exception/CustomException.java
+++ b/src/main/java/com/yfive/gbjs/global/error/exception/CustomException.java
@@ -1,0 +1,15 @@
+package com.yfive.gbjs.global.error.exception;
+
+import com.yfive.gbjs.global.error.exception.model.BaseErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+  private final BaseErrorCode errorCode;
+
+  public CustomException(BaseErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/com/yfive/gbjs/global/error/exception/model/BaseErrorCode.java
+++ b/src/main/java/com/yfive/gbjs/global/error/exception/model/BaseErrorCode.java
@@ -1,0 +1,12 @@
+package com.yfive.gbjs.global.error.exception.model;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode {
+
+  String getCode();
+
+  String getMessage();
+
+  HttpStatus getStatus();
+}


### PR DESCRIPTION
## ✨ 새로운 기능
- 기상청 OpenAPI를 연동하여 좌표 기반 날씨 상태 응답 API 구현
- 응답 결과를 통해 현재 위치(경도/위도)로 API 요청 시 날씨 상태 반환

## 🛠 개발 상세
- OpenAPI 공식 문서를 통한 경도/위도 -> nx/ny 좌표값 도출 구현
- RestClient를 사용하여 동기 처리

## 🧩 추가 고려사항
- [ ] 최저기온, 최고기온이 하루에 2번씩만 업데이트 되기 때문에 null 응답 시 이전 응답값을 유지해야 함
- [ ] 예외처리 및 주석 확인 필요

## 🔗 관련 문서 / 이슈
- close: #7