### PR TITLE
✨Feat: User 도메인 및 사용자 관련 기능 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,20 +28,20 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    
+
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.data:spring-data-redis'
-    
+
     // JWT
     implementation "io.jsonwebtoken:jjwt-api:${jjwtVersion}"
     runtimeOnly "io.jsonwebtoken:jjwt-impl:${jjwtVersion}"
     runtimeOnly "io.jsonwebtoken:jjwt-jackson:${jjwtVersion}"
-    
+
     // Springdoc OpenAPI
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${springdocVersion}"
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-api:${springdocVersion}"
-    
+
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly "com.mysql:mysql-connector-j:${mysqlVersion}"
@@ -50,6 +50,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.mockito:mockito-core'
+
+    // OAuth2
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {
@@ -61,22 +64,22 @@ spotless {
     java {
         // 구글 자바 코드 스타일 적용
         googleJavaFormat()
-        
+
         // 라이선스 헤더 추가
         licenseHeader '/* \n * Copyright (c) 2025 YFIVE\n */'
-        
+
         // 특정 import 순서 지정
         importOrder('java', 'javax', 'jakarta', 'org', 'com', '')
-        
+
         // 사용하지 않는 import 제거
         removeUnusedImports()
-        
+
         // 줄바꿈 통일
         endWithNewline()
-        
+
         // 들여쓰기에 탭 대신 스페이스 사용
         indentWithSpaces(4)
-        
+
         // 줄 끝 공백 제거
         trimTrailingWhitespace()
     }

--- a/src/main/java/com/yfive/gbjs/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/yfive/gbjs/domain/auth/dto/response/LoginResponse.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025 YFIVE
+ */
+package com.yfive.gbjs.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "LoginResponse DTO", description = "사용자 로그인에 대한 응답 반환")
+public class LoginResponse {
+
+  @Schema(description = "사용자 식별자", example = "1")
+  private Long userId;
+
+  @Schema(description = "소셜 로그인 이메일", example = "unijun0109@gmail.com")
+  private String email;
+
+  @Schema(description = "Access Token")
+  private String accessToken;
+
+  @Schema(description = "Access Token 만료 시간", example = "1800000")
+  private Long expirationTime;
+}

--- a/src/main/java/com/yfive/gbjs/domain/user/controller/UserController.java
+++ b/src/main/java/com/yfive/gbjs/domain/user/controller/UserController.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 YFIVE
+ */
+package com.yfive.gbjs.domain.user.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.yfive.gbjs.global.common.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "사용자", description = "사용자 관련 API")
+@RequestMapping("/api/users")
+public interface UserController {
+
+  @PutMapping("/email-marketing-consent")
+  @Operation(
+      summary = "이메일 수신 동의 토글",
+      description = "현재 로그인한 사용자의 이메일 마케팅 수신 여부를 반전시킵니다. (true → false, false → true)")
+  ResponseEntity<ApiResponse<Boolean>> updateEmailMarketingConsent();
+
+  @PutMapping("/push-notification-consent")
+  @Operation(
+      summary = "푸시 알림 수신 동의 토글",
+      description = "현재 로그인한 사용자의 푸시 알림 수신 여부를 반전시킵니다. (true → false, false → true)")
+  ResponseEntity<ApiResponse<Boolean>> updatePushNotificationConsent();
+
+  @PutMapping("/location-consent")
+  @Operation(
+      summary = "위치 정보 제공 동의 토글",
+      description = "현재 로그인한 사용자의 위치 정보 제공 동의 여부를 반전시킵니다. (true → false, false → true)")
+  ResponseEntity<ApiResponse<Boolean>> updateLocationConsent();
+
+  @PutMapping("/nickname")
+  @Operation(summary = "닉네임 수정", description = "현재 로그인한 사용자의 닉네임을 수정합니다.")
+  ResponseEntity<ApiResponse<String>> updateNickname(String newNickname);
+
+  @DeleteMapping
+  @Operation(summary = "회원 탈퇴", description = "현재 로그인한 사용자의 계정을 삭제합니다. (Hard Delete)")
+  ResponseEntity<ApiResponse<Void>> deleteUser();
+}

--- a/src/main/java/com/yfive/gbjs/domain/user/controller/UserController.java
+++ b/src/main/java/com/yfive/gbjs/domain/user/controller/UserController.java
@@ -35,9 +35,11 @@ public interface UserController {
       description = "현재 로그인한 사용자의 위치 정보 제공 동의 여부를 반전시킵니다. (true → false, false → true)")
   ResponseEntity<ApiResponse<Boolean>> updateLocationConsent();
 
+import org.springframework.web.bind.annotation.RequestParam;
+
   @PutMapping("/nickname")
   @Operation(summary = "닉네임 수정", description = "현재 로그인한 사용자의 닉네임을 수정합니다.")
-  ResponseEntity<ApiResponse<String>> updateNickname(String newNickname);
+  ResponseEntity<ApiResponse<String>> updateNickname(@RequestParam String newNickname);
 
   @DeleteMapping
   @Operation(summary = "회원 탈퇴", description = "현재 로그인한 사용자의 계정을 삭제합니다. (Hard Delete)")

--- a/src/main/java/com/yfive/gbjs/domain/user/controller/UserController.java
+++ b/src/main/java/com/yfive/gbjs/domain/user/controller/UserController.java
@@ -35,11 +35,9 @@ public interface UserController {
       description = "현재 로그인한 사용자의 위치 정보 제공 동의 여부를 반전시킵니다. (true → false, false → true)")
   ResponseEntity<ApiResponse<Boolean>> updateLocationConsent();
 
-import org.springframework.web.bind.annotation.RequestParam;
-
   @PutMapping("/nickname")
   @Operation(summary = "닉네임 수정", description = "현재 로그인한 사용자의 닉네임을 수정합니다.")
-  ResponseEntity<ApiResponse<String>> updateNickname(@RequestParam String newNickname);
+  ResponseEntity<ApiResponse<String>> updateNickname(String newNickname);
 
   @DeleteMapping
   @Operation(summary = "회원 탈퇴", description = "현재 로그인한 사용자의 계정을 삭제합니다. (Hard Delete)")

--- a/src/main/java/com/yfive/gbjs/domain/user/controller/UserControllerImpl.java
+++ b/src/main/java/com/yfive/gbjs/domain/user/controller/UserControllerImpl.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025 YFIVE
+ */
+package com.yfive.gbjs.domain.user.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.yfive.gbjs.domain.user.service.UserService;
+import com.yfive.gbjs.global.common.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class UserControllerImpl implements UserController {
+
+  private final UserService userService;
+
+  @Override
+  public ResponseEntity<ApiResponse<Boolean>> updateEmailMarketingConsent() {
+    return ResponseEntity.ok(ApiResponse.success(userService.toggleEmailMarketingConsent()));
+  }
+
+  @Override
+  public ResponseEntity<ApiResponse<Boolean>> updatePushNotificationConsent() {
+    return ResponseEntity.ok(ApiResponse.success(userService.togglePushNotificationConsent()));
+  }
+
+  @Override
+  public ResponseEntity<ApiResponse<Boolean>> updateLocationConsent() {
+    return ResponseEntity.ok(ApiResponse.success(userService.toggleLocationConsent()));
+  }
+
+  @Override
+  public ResponseEntity<ApiResponse<String>> updateNickname(String newNickname) {
+    return ResponseEntity.ok(ApiResponse.success(userService.updateNickname(newNickname)));
+  }
+
+  @Override
+  public ResponseEntity<ApiResponse<Void>> deleteUser() {
+    userService.deleteUser();
+    return ResponseEntity.ok(ApiResponse.success());
+  }
+}

--- a/src/main/java/com/yfive/gbjs/domain/user/entity/User.java
+++ b/src/main/java/com/yfive/gbjs/domain/user/entity/User.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025 YFIVE
+ */
+package com.yfive.gbjs.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "users")
+public class User {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id")
+  private Long id;
+
+  @Column(name = "nickname", nullable = false, unique = true)
+  private String nickname;
+
+  @Column(name = "username", nullable = false, unique = true)
+  private String username;
+
+  @Column(name = "email_marketing_consent", nullable = false)
+  private Boolean emailMarketingConsent;
+
+  // 알림 수신 여부 (푸시 알림)
+  @Column(name = "push_notification_consent", nullable = false)
+  private Boolean pushNotificationConsent;
+
+  // 위치 정보 수집 동의 여부
+  @Column(name = "location_consent", nullable = false)
+  private Boolean locationConsent;
+
+  public static User fromOAuth(String email, String nickname) {
+    return User.builder()
+        .username(email)
+        .nickname(nickname)
+        .emailMarketingConsent(false)
+        .pushNotificationConsent(false)
+        .locationConsent(false)
+        .build();
+  }
+
+  public void toggleEmailMarketingConsent() {
+    this.emailMarketingConsent = this.emailMarketingConsent == null || !this.emailMarketingConsent;
+  }
+
+  public void togglePushNotificationConsent() {
+    this.pushNotificationConsent =
+        this.pushNotificationConsent == null || !this.pushNotificationConsent;
+  }
+
+  public void toggleLocationConsent() {
+    this.locationConsent = this.locationConsent == null || !this.locationConsent;
+  }
+
+  public void updateNickname(String newNickname) {
+    this.nickname = newNickname;
+  }
+}

--- a/src/main/java/com/yfive/gbjs/domain/user/exception/UserErrorStatus.java
+++ b/src/main/java/com/yfive/gbjs/domain/user/exception/UserErrorStatus.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 YFIVE
+ */
+package com.yfive.gbjs.domain.user.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.yfive.gbjs.global.error.exception.model.BaseErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserErrorStatus implements BaseErrorCode {
+  USER_NOT_FOUND("USER001", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  EXIST_NICKNAME("USER002", "이미 존재하는 닉네임입니다.", HttpStatus.BAD_REQUEST),
+  UNAUTHORIZED("USER003", "인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
+  ;
+
+  private final String code;
+  private final String message;
+  private final HttpStatus status;
+}

--- a/src/main/java/com/yfive/gbjs/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/yfive/gbjs/domain/user/repository/UserRepository.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 YFIVE
+ */
+package com.yfive.gbjs.domain.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.yfive.gbjs.domain.user.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  Optional<User> findByUsername(String username);
+
+  Optional<User> findByNickname(String nickname);
+}

--- a/src/main/java/com/yfive/gbjs/domain/user/service/UserService.java
+++ b/src/main/java/com/yfive/gbjs/domain/user/service/UserService.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025 YFIVE
+ */
+package com.yfive.gbjs.domain.user.service;
+
+public interface UserService {
+
+  boolean toggleEmailMarketingConsent();
+
+  boolean togglePushNotificationConsent();
+
+  boolean toggleLocationConsent();
+
+  String updateNickname(String newNickname);
+
+  void deleteUser();
+}

--- a/src/main/java/com/yfive/gbjs/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/yfive/gbjs/domain/user/service/UserServiceImpl.java
@@ -3,6 +3,8 @@
  */
 package com.yfive.gbjs.domain.user.service;
 
+import java.util.Map;
+
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -87,10 +89,13 @@ public class UserServiceImpl implements UserService {
     }
 
     Object principal = authentication.getPrincipal();
-    String username;
+    String username = "";
 
     if (principal instanceof OAuth2User oauthUser) {
-      username = oauthUser.getAttribute("email");
+      Map<String, Object> kakaoAccount = oauthUser.getAttribute("kakao_account");
+      if (kakaoAccount != null && kakaoAccount.containsKey("email")) {
+        username = (String) kakaoAccount.get("email");
+      }
     } else if (principal instanceof String str) {
       username = str;
     } else if (principal instanceof UserDetails userDetails) {

--- a/src/main/java/com/yfive/gbjs/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/yfive/gbjs/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2025 YFIVE
+ */
+package com.yfive.gbjs.domain.user.service;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.yfive.gbjs.domain.user.entity.User;
+import com.yfive.gbjs.domain.user.exception.UserErrorStatus;
+import com.yfive.gbjs.domain.user.repository.UserRepository;
+import com.yfive.gbjs.global.error.exception.CustomException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+  private final UserRepository userRepository;
+
+  @Transactional
+  @Override
+  public boolean toggleEmailMarketingConsent() {
+    User user = getCurrentUser();
+    user.toggleEmailMarketingConsent();
+    userRepository.save(user);
+    log.info("사용자 {} 이메일 마케팅 수신 동의 상태 변경: {}", user.getUsername(), user.getEmailMarketingConsent());
+    return user.getEmailMarketingConsent();
+  }
+
+  @Transactional
+  @Override
+  public boolean togglePushNotificationConsent() {
+    User user = getCurrentUser();
+    user.togglePushNotificationConsent();
+    userRepository.save(user);
+    log.info("사용자 {} 푸시 알림 수신 동의 상태 변경: {}", user.getUsername(), user.getPushNotificationConsent());
+    return user.getPushNotificationConsent();
+  }
+
+  @Transactional
+  @Override
+  public boolean toggleLocationConsent() {
+    User user = getCurrentUser();
+    user.toggleLocationConsent();
+    userRepository.save(user);
+    log.info("사용자 {} 위치 정보 제공 동의 상태 변경: {}", user.getUsername(), user.getLocationConsent());
+    return user.getLocationConsent();
+  }
+
+  @Transactional
+  @Override
+  public String updateNickname(String newNickname) {
+    User user = getCurrentUser();
+
+    if (userRepository.findByNickname(newNickname).isPresent()) {
+      log.error("닉네임 중복 시도: {}", newNickname);
+      throw new CustomException(UserErrorStatus.EXIST_NICKNAME);
+    }
+
+    user.updateNickname(newNickname);
+    userRepository.save(user);
+    log.info("사용자 {} 닉네임 변경: {}", user.getUsername(), newNickname);
+    return newNickname;
+  }
+
+  @Transactional
+  @Override
+  public void deleteUser() {
+    User user = getCurrentUser();
+    userRepository.delete(user);
+    log.info("사용자 {}님의 계정이 삭제되었습니다.", user.getUsername());
+  }
+
+  public User getCurrentUser() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    if (authentication == null || !authentication.isAuthenticated()) {
+      throw new CustomException(UserErrorStatus.UNAUTHORIZED);
+    }
+
+    Object principal = authentication.getPrincipal();
+    String username;
+
+    if (principal instanceof OAuth2User oauthUser) {
+      username = oauthUser.getAttribute("email");
+    } else if (principal instanceof String str) {
+      username = str;
+    } else if (principal instanceof UserDetails userDetails) {
+      username = userDetails.getUsername();
+    } else {
+      throw new CustomException(UserErrorStatus.UNAUTHORIZED);
+    }
+
+    if (username == null || username.isBlank()) {
+      throw new CustomException(UserErrorStatus.UNAUTHORIZED);
+    }
+
+    return userRepository
+        .findByUsername(username)
+        .orElseThrow(() -> new CustomException(UserErrorStatus.USER_NOT_FOUND));
+  }
+}

--- a/src/main/java/com/yfive/gbjs/global/config/SecurityConfig.java
+++ b/src/main/java/com/yfive/gbjs/global/config/SecurityConfig.java
@@ -3,13 +3,9 @@
  */
 package com.yfive.gbjs.global.config;
 
-import com.yfive.gbjs.global.config.jwt.JwtFilter;
-import com.yfive.gbjs.global.config.jwt.JwtTokenProvider;
-import com.yfive.gbjs.global.security.CustomOAuth2UserService;
-import com.yfive.gbjs.global.security.OAuth2LoginSuccessHandler;
 import java.util.Arrays;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -23,6 +19,13 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import com.yfive.gbjs.global.config.jwt.JwtFilter;
+import com.yfive.gbjs.global.config.jwt.JwtTokenProvider;
+import com.yfive.gbjs.global.security.CustomOAuth2UserService;
+import com.yfive.gbjs.global.security.OAuth2LoginSuccessHandler;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
@@ -84,9 +87,9 @@ public class SecurityConfig {
                 oauth2
                     .userInfoEndpoint(
                         userInfo -> userInfo.userService(oauth2UserService) // 사용자 정보 처리
-                    )
+                        )
                     .successHandler(customSuccessHandler) // 로그인 성공 처리
-        );
+            );
 
     return http.build();
   }

--- a/src/main/java/com/yfive/gbjs/global/config/SecurityConfig.java
+++ b/src/main/java/com/yfive/gbjs/global/config/SecurityConfig.java
@@ -3,9 +3,13 @@
  */
 package com.yfive.gbjs.global.config;
 
+import com.yfive.gbjs.global.config.jwt.JwtFilter;
+import com.yfive.gbjs.global.config.jwt.JwtTokenProvider;
+import com.yfive.gbjs.global.security.CustomOAuth2UserService;
+import com.yfive.gbjs.global.security.OAuth2LoginSuccessHandler;
 import java.util.Arrays;
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -19,13 +23,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import com.yfive.gbjs.global.config.jwt.JwtFilter;
-import com.yfive.gbjs.global.config.jwt.JwtTokenProvider;
-import com.yfive.gbjs.global.security.CustomOAuth2UserService;
-import com.yfive.gbjs.global.security.OAuth2LoginSuccessHandler;
-
-import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
@@ -73,7 +70,7 @@ public class SecurityConfig {
                         "/webjars/**")
                     .permitAll()
                     // 공개 API
-                    .requestMatchers("/api/auth/**", "/api/guides/**", "api/weathers")
+                    .requestMatchers("/api/auth/**", "/api/guides/**", "api/weathers", "api/users")
                     .permitAll()
                     // H2 콘솔
                     .requestMatchers("/h2-console/**")
@@ -87,9 +84,9 @@ public class SecurityConfig {
                 oauth2
                     .userInfoEndpoint(
                         userInfo -> userInfo.userService(oauth2UserService) // 사용자 정보 처리
-                        )
+                    )
                     .successHandler(customSuccessHandler) // 로그인 성공 처리
-            );
+        );
 
     return http.build();
   }

--- a/src/main/java/com/yfive/gbjs/global/config/jwt/JwtFilter.java
+++ b/src/main/java/com/yfive/gbjs/global/config/jwt/JwtFilter.java
@@ -39,6 +39,7 @@ public class JwtFilter extends OncePerRequestFilter {
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
     String jwt = resolveToken(request);
+    log.debug("jwt: {}", jwt);
 
     if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
       // Access Token인지 확인

--- a/src/main/java/com/yfive/gbjs/global/config/jwt/JwtFilter.java
+++ b/src/main/java/com/yfive/gbjs/global/config/jwt/JwtFilter.java
@@ -39,7 +39,6 @@ public class JwtFilter extends OncePerRequestFilter {
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
     String jwt = resolveToken(request);
-    log.debug("jwt: {}", jwt);
 
     if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
       // Access Token인지 확인

--- a/src/main/java/com/yfive/gbjs/global/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/yfive/gbjs/global/config/jwt/JwtTokenProvider.java
@@ -332,6 +332,17 @@ public class JwtTokenProvider {
     return storedToken != null && storedToken.equals(refreshToken);
   }
 
+  /**
+   * JWT 토큰을 HTTP 응답의 쿠키에 추가합니다.
+   *
+   * <p>이 메서드는 주어진 JWT 토큰을 HttpOnly 및 Secure 속성이 설정된 쿠키로 만들어 응답에 추가합니다. 이 쿠키는 클라이언트에서 JavaScript로
+   * 접근할 수 없으며, HTTPS 환경에서만 전송됩니다.
+   *
+   * @param response 응답 객체 (HttpServletResponse)
+   * @param token 쿠키에 저장할 JWT 토큰 값
+   * @param name 쿠키 이름 (예: "accessToken", "refreshToken")
+   * @param maxAge 쿠키의 유효 시간 (밀리초 단위)
+   */
   public void addJwtToCookie(HttpServletResponse response, String token, String name, long maxAge) {
     Cookie cookie = new Cookie(name, token);
     cookie.setHttpOnly(true);

--- a/src/main/java/com/yfive/gbjs/global/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/yfive/gbjs/global/config/jwt/JwtTokenProvider.java
@@ -6,21 +6,26 @@ package com.yfive.gbjs.global.config.jwt;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.crypto.SecretKey;
 
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 
 import com.yfive.gbjs.domain.auth.dto.response.TokenResponse;
+import com.yfive.gbjs.domain.user.exception.UserErrorStatus;
+import com.yfive.gbjs.global.error.exception.CustomException;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -133,6 +138,15 @@ public class JwtTokenProvider {
             .map(GrantedAuthority::getAuthority)
             .collect(Collectors.joining(","));
 
+    OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+    Map<String, Object> kakaoAccount = oAuth2User.getAttribute("kakao_account");
+
+    if (kakaoAccount == null || !kakaoAccount.containsKey("email")) {
+      throw new CustomException(UserErrorStatus.UNAUTHORIZED);
+    }
+
+    String email = (String) kakaoAccount.get("email");
+
     long now = System.currentTimeMillis();
     Date validity;
 
@@ -144,7 +158,7 @@ public class JwtTokenProvider {
     }
 
     return Jwts.builder()
-        .setSubject(authentication.getName())
+        .setSubject(email)
         .claim("auth", authorities)
         .claim("type", tokenType)
         .setIssuedAt(new Date(now))
@@ -179,7 +193,8 @@ public class JwtTokenProvider {
             .map(SimpleGrantedAuthority::new)
             .collect(Collectors.toList());
 
-    UserDetails principal = new User(claims.getSubject(), "", authorities);
+    Map<String, Object> attributes = Map.of("email", claims.getSubject());
+    OAuth2User principal = new DefaultOAuth2User(authorities, attributes, "email");
     return new UsernamePasswordAuthenticationToken(principal, token, authorities);
   }
 
@@ -315,5 +330,16 @@ public class JwtTokenProvider {
   public boolean validateRefreshToken(String username, String refreshToken) {
     String storedToken = tokenRepository.findRefreshToken(username);
     return storedToken != null && storedToken.equals(refreshToken);
+  }
+
+  public void addJwtToCookie(HttpServletResponse response, String token, String name, long maxAge) {
+    Cookie cookie = new Cookie(name, token);
+    cookie.setHttpOnly(true);
+    // cookie.setSecure(true);
+    cookie.setPath("/");
+    cookie.setMaxAge((int) (maxAge / 1000));
+    response.addCookie(cookie);
+
+    log.info("JWT 쿠키가 설정되었습니다 - 이름: {}, 만료: {}초", name, cookie.getMaxAge());
   }
 }

--- a/src/main/java/com/yfive/gbjs/global/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/yfive/gbjs/global/security/CustomOAuth2UserService.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025 YFIVE
+ */
+package com.yfive.gbjs.global.security;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import com.yfive.gbjs.domain.user.entity.User;
+import com.yfive.gbjs.domain.user.repository.UserRepository;
+import com.yfive.gbjs.global.config.jwt.JwtTokenProvider;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+  private final UserRepository userRepository;
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @Override
+  public OAuth2User loadUser(OAuth2UserRequest request) throws OAuth2AuthenticationException {
+    OAuth2User oauth2User = new DefaultOAuth2UserService().loadUser(request);
+    String registrationId = request.getClientRegistration().getRegistrationId();
+
+    Map<String, Object> attributes = oauth2User.getAttributes();
+
+    String email = extractEmail(registrationId, attributes);
+
+    String nickname = extractNickname(registrationId, attributes);
+
+    User user =
+        userRepository
+            .findByUsername(email)
+            .orElseGet(() -> userRepository.save(User.fromOAuth(email, nickname)));
+
+    log.info("사용자 로그인 성공: {}", user.getUsername());
+
+    return new DefaultOAuth2User(
+        Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")), attributes, "id");
+  }
+
+  private String extractEmail(String provider, Map<String, Object> attributes) {
+    if ("kakao".equals(provider)) {
+      Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+      if (account == null || !account.containsKey("email")) {
+        log.warn("카카오 계정에서 이메일을 찾을 수 없습니다.");
+        throw new OAuth2AuthenticationException("카카오 계정에 이메일이 없습니다.");
+      }
+      return (String) account.get("email");
+    }
+    throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인입니다.");
+  }
+
+  private String extractNickname(String provider, Map<String, Object> attributes) {
+    if ("kakao".equals(provider)) {
+      Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+      Map<String, Object> profile =
+          account != null ? (Map<String, Object>) account.get("profile") : null;
+      if (profile != null && profile.get("nickname") != null) {
+        return (String) profile.get("nickname");
+      } else {
+        String randomNickname = "user_" + UUID.randomUUID().toString().substring(0, 8);
+        log.info("닉네임 정보 없음 - 랜덤 닉네임 생성: {}", randomNickname);
+        return randomNickname;
+      }
+    }
+    String randomNickname = "user_" + UUID.randomUUID().toString().substring(0, 8);
+    log.info("닉네임 정보 없음 - 랜덤 닉네임 생성: {}", randomNickname);
+    return randomNickname;
+  }
+}

--- a/src/main/java/com/yfive/gbjs/global/security/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/yfive/gbjs/global/security/OAuth2LoginSuccessHandler.java
@@ -63,7 +63,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         response,
         tokenResponse.getAccessToken(),
         "ACCESS_TOKEN",
-        jwtProvider.getExpirationTime(tokenResponse.getRefreshToken()));
+        jwtProvider.getExpirationTime(tokenResponse.getAccessToken()));
 
     log.info("카카오 로그인 성공: {}", user.getUsername());
 

--- a/src/main/java/com/yfive/gbjs/global/security/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/yfive/gbjs/global/security/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025 YFIVE
+ */
+package com.yfive.gbjs.global.security;
+
+import java.io.IOException;
+import java.util.Map;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.yfive.gbjs.domain.auth.dto.response.TokenResponse;
+import com.yfive.gbjs.domain.user.entity.User;
+import com.yfive.gbjs.domain.user.exception.UserErrorStatus;
+import com.yfive.gbjs.domain.user.repository.UserRepository;
+import com.yfive.gbjs.global.config.jwt.JwtTokenProvider;
+import com.yfive.gbjs.global.error.exception.CustomException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+  private final JwtTokenProvider jwtProvider;
+  private final UserRepository userRepository;
+
+  @Override
+  @Transactional
+  public void onAuthenticationSuccess(
+      HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+      throws IOException {
+
+    OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+    Map<String, Object> kakaoAccount = oAuth2User.getAttribute("kakao_account");
+
+    if (kakaoAccount == null || !kakaoAccount.containsKey("email")) {
+      throw new CustomException(UserErrorStatus.UNAUTHORIZED);
+    }
+
+    String email = (String) kakaoAccount.get("email");
+
+    User user =
+        userRepository
+            .findByUsername(email)
+            .orElseThrow(() -> new CustomException(UserErrorStatus.USER_NOT_FOUND));
+
+    TokenResponse tokenResponse = jwtProvider.createTokens(authentication);
+    jwtProvider.addJwtToCookie(
+        response,
+        tokenResponse.getRefreshToken(),
+        "REFRESH_TOKEN",
+        jwtProvider.getExpirationTime(tokenResponse.getRefreshToken()));
+    jwtProvider.addJwtToCookie(
+        response,
+        tokenResponse.getAccessToken(),
+        "ACCESS_TOKEN",
+        jwtProvider.getExpirationTime(tokenResponse.getRefreshToken()));
+
+    log.info("카카오 로그인 성공: {}", user.getUsername());
+
+    response.addHeader("Authorization", "Bearer " + tokenResponse.getAccessToken());
+    response.sendRedirect("/swagger-ui/index.html#/");
+  }
+}

--- a/src/test/java/com/yfive/gbjs/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/yfive/gbjs/domain/auth/controller/AuthControllerTest.java
@@ -13,6 +13,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yfive.gbjs.domain.auth.dto.request.LoginRequest;
+import com.yfive.gbjs.domain.auth.dto.request.TokenRefreshRequest;
+import com.yfive.gbjs.domain.auth.dto.response.TokenResponse;
+import com.yfive.gbjs.domain.auth.service.AuthService;
+import com.yfive.gbjs.global.config.MockRedisConfig;
+import com.yfive.gbjs.global.config.SecurityConfig;
+import com.yfive.gbjs.global.config.TestJwtPropertiesConfig;
+import com.yfive.gbjs.global.config.jwt.JwtTokenProvider;
+import com.yfive.gbjs.global.error.exception.InvalidTokenException;
+import com.yfive.gbjs.global.security.CustomOAuth2UserService;
+import com.yfive.gbjs.global.security.OAuth2LoginSuccessHandler;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,29 +36,28 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.yfive.gbjs.domain.auth.dto.request.LoginRequest;
-import com.yfive.gbjs.domain.auth.dto.request.TokenRefreshRequest;
-import com.yfive.gbjs.domain.auth.dto.response.TokenResponse;
-import com.yfive.gbjs.domain.auth.service.AuthService;
-import com.yfive.gbjs.global.config.MockRedisConfig;
-import com.yfive.gbjs.global.config.SecurityConfig;
-import com.yfive.gbjs.global.config.TestJwtPropertiesConfig;
-import com.yfive.gbjs.global.config.jwt.JwtTokenProvider;
-import com.yfive.gbjs.global.error.exception.InvalidTokenException;
-
 @WebMvcTest(AuthControllerImpl.class)
 @Import({SecurityConfig.class, TestJwtPropertiesConfig.class, MockRedisConfig.class})
 @ActiveProfiles("test")
 class AuthControllerTest {
 
-  @Autowired private MockMvc mockMvc;
+  @Autowired
+  private MockMvc mockMvc;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  private ObjectMapper objectMapper;
 
-  @MockitoBean private AuthService authService;
+  @MockitoBean
+  private AuthService authService;
 
-  @MockitoBean private JwtTokenProvider jwtTokenProvider;
+  @MockitoBean
+  private JwtTokenProvider jwtTokenProvider;
+
+  @MockitoBean
+  private CustomOAuth2UserService customOAuth2UserService;
+
+  @MockitoBean
+  private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
 
   @Test
   @DisplayName("로그인 API 테스트")

--- a/src/test/java/com/yfive/gbjs/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/yfive/gbjs/domain/auth/controller/AuthControllerTest.java
@@ -13,6 +13,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yfive.gbjs.domain.auth.dto.request.LoginRequest;
 import com.yfive.gbjs.domain.auth.dto.request.TokenRefreshRequest;
@@ -25,39 +36,23 @@ import com.yfive.gbjs.global.config.jwt.JwtTokenProvider;
 import com.yfive.gbjs.global.error.exception.InvalidTokenException;
 import com.yfive.gbjs.global.security.CustomOAuth2UserService;
 import com.yfive.gbjs.global.security.OAuth2LoginSuccessHandler;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(AuthControllerImpl.class)
 @Import({SecurityConfig.class, TestJwtPropertiesConfig.class, MockRedisConfig.class})
 @ActiveProfiles("test")
 class AuthControllerTest {
 
-  @Autowired
-  private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
-  @Autowired
-  private ObjectMapper objectMapper;
+  @Autowired private ObjectMapper objectMapper;
 
-  @MockitoBean
-  private AuthService authService;
+  @MockitoBean private AuthService authService;
 
-  @MockitoBean
-  private JwtTokenProvider jwtTokenProvider;
+  @MockitoBean private JwtTokenProvider jwtTokenProvider;
 
-  @MockitoBean
-  private CustomOAuth2UserService customOAuth2UserService;
+  @MockitoBean private CustomOAuth2UserService customOAuth2UserService;
 
-  @MockitoBean
-  private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+  @MockitoBean private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
 
   @Test
   @DisplayName("로그인 API 테스트")

--- a/src/test/java/com/yfive/gbjs/global/config/SecurityConfigTest.java
+++ b/src/test/java/com/yfive/gbjs/global/config/SecurityConfigTest.java
@@ -6,43 +6,48 @@ package com.yfive.gbjs.global.config;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.yfive.gbjs.domain.auth.service.AuthService;
+import com.yfive.gbjs.global.config.jwt.JwtTokenProvider;
+import com.yfive.gbjs.global.config.jwt.TokenRepository;
+import com.yfive.gbjs.global.security.CustomOAuth2UserService;
+import com.yfive.gbjs.global.security.OAuth2LoginSuccessHandler;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.yfive.gbjs.domain.auth.controller.AuthControllerImpl;
-import com.yfive.gbjs.domain.auth.controller.MockController;
-import com.yfive.gbjs.domain.auth.service.AuthService;
-import com.yfive.gbjs.domain.user.controller.ProtectedController;
-import com.yfive.gbjs.global.config.jwt.JwtTokenProvider;
-import com.yfive.gbjs.global.config.jwt.TokenRepository;
-
-@WebMvcTest(
-    controllers = {AuthControllerImpl.class, ProtectedController.class, MockController.class})
-@Import({SecurityConfig.class, TestJwtPropertiesConfig.class, MockRedisConfig.class})
+@SpringBootTest
+@AutoConfigureMockMvc
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
 class SecurityConfigTest {
 
-  @Autowired private MockMvc mockMvc;
+  @Autowired
+  private MockMvc mockMvc;
 
-  @MockitoBean private JwtTokenProvider jwtTokenProvider;
+  @MockitoBean
+  private JwtTokenProvider jwtTokenProvider;
 
-  @MockitoBean private AuthService authService;
+  @MockitoBean
+  private AuthService authService;
 
-  @MockitoBean private TokenRepository tokenRepository;
+  @MockitoBean
+  private TokenRepository tokenRepository;
+
+  @MockitoBean
+  private CustomOAuth2UserService customOAuth2UserService;
+
+  @MockitoBean
+  private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
 
   @Test
   @DisplayName("인증되지 않은 사용자는 보호된 엔드포인트에 접근할 수 없다")
   void unauthenticatedUserCannotAccessProtectedEndpoints() throws Exception {
-    mockMvc.perform(get("/api/protected")).andExpect(status().isForbidden());
+    mockMvc.perform(get("/api/protected"))
+        .andExpect(status().isFound());  // 403 -> 302로 변경
   }
 
   @Test

--- a/src/test/java/com/yfive/gbjs/global/config/SecurityConfigTest.java
+++ b/src/test/java/com/yfive/gbjs/global/config/SecurityConfigTest.java
@@ -6,11 +6,6 @@ package com.yfive.gbjs.global.config;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.yfive.gbjs.domain.auth.service.AuthService;
-import com.yfive.gbjs.global.config.jwt.JwtTokenProvider;
-import com.yfive.gbjs.global.config.jwt.TokenRepository;
-import com.yfive.gbjs.global.security.CustomOAuth2UserService;
-import com.yfive.gbjs.global.security.OAuth2LoginSuccessHandler;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,34 +15,33 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.yfive.gbjs.domain.auth.service.AuthService;
+import com.yfive.gbjs.global.config.jwt.JwtTokenProvider;
+import com.yfive.gbjs.global.config.jwt.TokenRepository;
+import com.yfive.gbjs.global.security.CustomOAuth2UserService;
+import com.yfive.gbjs.global.security.OAuth2LoginSuccessHandler;
+
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 class SecurityConfigTest {
 
-  @Autowired
-  private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
-  @MockitoBean
-  private JwtTokenProvider jwtTokenProvider;
+  @MockitoBean private JwtTokenProvider jwtTokenProvider;
 
-  @MockitoBean
-  private AuthService authService;
+  @MockitoBean private AuthService authService;
 
-  @MockitoBean
-  private TokenRepository tokenRepository;
+  @MockitoBean private TokenRepository tokenRepository;
 
-  @MockitoBean
-  private CustomOAuth2UserService customOAuth2UserService;
+  @MockitoBean private CustomOAuth2UserService customOAuth2UserService;
 
-  @MockitoBean
-  private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+  @MockitoBean private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
 
   @Test
   @DisplayName("인증되지 않은 사용자는 보호된 엔드포인트에 접근할 수 없다")
   void unauthenticatedUserCannotAccessProtectedEndpoints() throws Exception {
-    mockMvc.perform(get("/api/protected"))
-        .andExpect(status().isFound());  // 403 -> 302로 변경
+    mockMvc.perform(get("/api/protected")).andExpect(status().isFound()); // 403 -> 302로 변경
   }
 
   @Test

--- a/src/test/java/com/yfive/gbjs/global/config/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/yfive/gbjs/global/config/jwt/JwtTokenProviderTest.java
@@ -8,8 +8,9 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.yfive.gbjs.domain.auth.dto.response.TokenResponse;
 import java.util.Collections;
-
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,9 +18,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
-
-import com.yfive.gbjs.domain.auth.dto.response.TokenResponse;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 /**
  * JWT 토큰 제공자 테스트 클래스
@@ -63,7 +63,9 @@ class JwtTokenProviderTest {
     when(tokenRepository.isBlacklisted(anyString())).thenReturn(false);
   }
 
-  /** 인증 정보로 JWT 토큰 생성 및 검증 테스트 */
+  /**
+   * 인증 정보로 JWT 토큰 생성 및 검증 테스트
+   */
   @Test
   @DisplayName("인증 정보로 JWT 토큰을 생성하고 검증할 수 있다")
   void createAndValidateToken() {
@@ -79,7 +81,9 @@ class JwtTokenProviderTest {
     assertThat(jwtTokenProvider.validateToken(token)).isTrue();
   }
 
-  /** JWT 토큰에서 인증 정보 추출 테스트 */
+  /**
+   * JWT 토큰에서 인증 정보 추출 테스트
+   */
   @Test
   @DisplayName("JWT 토큰에서 인증 정보를 추출할 수 있다")
   void getAuthenticationFromToken() {
@@ -99,7 +103,9 @@ class JwtTokenProviderTest {
         .containsExactly("ROLE_USER");
   }
 
-  /** 액세스 토큰과 리프레시 토큰 생성 테스트 */
+  /**
+   * 액세스 토큰과 리프레시 토큰 생성 테스트
+   */
   @Test
   @DisplayName("액세스 토큰과 리프레시 토큰을 모두 생성할 수 있다")
   void createBothTokens() {
@@ -123,9 +129,21 @@ class JwtTokenProviderTest {
    * @param username 사용자 이름
    * @return 인증 객체
    */
-  private Authentication createAuthentication(String username) {
+  private Authentication createAuthentication(String email) {
     SimpleGrantedAuthority authority = new SimpleGrantedAuthority("ROLE_USER");
-    User principal = new User(username, "", Collections.singleton(authority));
+
+    Map<String, Object> kakaoAccount = Map.of("email", email);
+    Map<String, Object> attributes = Map.of(
+        "email", email,
+        "kakao_account", kakaoAccount
+    );
+
+    OAuth2User principal = new DefaultOAuth2User(
+        Collections.singleton(authority),
+        attributes,
+        "email"
+    );
+
     return new UsernamePasswordAuthenticationToken(principal, "", Collections.singleton(authority));
   }
 }

--- a/src/test/java/com/yfive/gbjs/global/config/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/yfive/gbjs/global/config/jwt/JwtTokenProviderTest.java
@@ -8,9 +8,9 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.yfive.gbjs.domain.auth.dto.response.TokenResponse;
 import java.util.Collections;
 import java.util.Map;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,6 +20,8 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import com.yfive.gbjs.domain.auth.dto.response.TokenResponse;
 
 /**
  * JWT 토큰 제공자 테스트 클래스
@@ -63,9 +65,7 @@ class JwtTokenProviderTest {
     when(tokenRepository.isBlacklisted(anyString())).thenReturn(false);
   }
 
-  /**
-   * 인증 정보로 JWT 토큰 생성 및 검증 테스트
-   */
+  /** 인증 정보로 JWT 토큰 생성 및 검증 테스트 */
   @Test
   @DisplayName("인증 정보로 JWT 토큰을 생성하고 검증할 수 있다")
   void createAndValidateToken() {
@@ -81,9 +81,7 @@ class JwtTokenProviderTest {
     assertThat(jwtTokenProvider.validateToken(token)).isTrue();
   }
 
-  /**
-   * JWT 토큰에서 인증 정보 추출 테스트
-   */
+  /** JWT 토큰에서 인증 정보 추출 테스트 */
   @Test
   @DisplayName("JWT 토큰에서 인증 정보를 추출할 수 있다")
   void getAuthenticationFromToken() {
@@ -103,9 +101,7 @@ class JwtTokenProviderTest {
         .containsExactly("ROLE_USER");
   }
 
-  /**
-   * 액세스 토큰과 리프레시 토큰 생성 테스트
-   */
+  /** 액세스 토큰과 리프레시 토큰 생성 테스트 */
   @Test
   @DisplayName("액세스 토큰과 리프레시 토큰을 모두 생성할 수 있다")
   void createBothTokens() {
@@ -133,16 +129,13 @@ class JwtTokenProviderTest {
     SimpleGrantedAuthority authority = new SimpleGrantedAuthority("ROLE_USER");
 
     Map<String, Object> kakaoAccount = Map.of("email", email);
-    Map<String, Object> attributes = Map.of(
-        "email", email,
-        "kakao_account", kakaoAccount
-    );
+    Map<String, Object> attributes =
+        Map.of(
+            "email", email,
+            "kakao_account", kakaoAccount);
 
-    OAuth2User principal = new DefaultOAuth2User(
-        Collections.singleton(authority),
-        attributes,
-        "email"
-    );
+    OAuth2User principal =
+        new DefaultOAuth2User(Collections.singleton(authority), attributes, "email");
 
     return new UsernamePasswordAuthenticationToken(principal, "", Collections.singleton(authority));
   }


### PR DESCRIPTION
## ✨ 새로운 기능
- 카카오 소셜 로그인
- 사용자 동의 항목별 토글 기능
- 사용자 닉네임 변경
- 회원 탈퇴

## 🛠 개발 상세
- 카카오 소셜 로그인 연동

## 🧪 테스트 방법
- [ ] 추후 테스트 케이스 작성 필요

## 🧩 추가 고려사항
- [ ] Seal 도메인 작업 후 필드 수정 및 매핑테이블 생성 필요

## 🔗 관련 문서 / 이슈
- issue: #18 
- close: #18 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 카카오 소셜 로그인을 지원하는 OAuth2 인증 기능이 추가되었습니다.
  * 사용자 정보 및 동의(이메일 마케팅, 푸시 알림, 위치 정보) 관리 API가 추가되었습니다.
  * JWT 토큰이 OAuth2 로그인 시 쿠키로 발급됩니다.

* **버그 수정**
  * 인증되지 않은 사용자의 접근 시 HTTP 302 리다이렉트로 동작하도록 테스트가 수정되었습니다.

* **문서화**
  * Swagger를 통한 API 문서화가 강화되었습니다.

* **테스트**
  * OAuth2 및 JWT 관련 보안 테스트와 모킹이 추가 및 개선되었습니다.

* **기타**
  * 코드 스타일 및 의존성 관리가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->