### PR TITLE
♻️refactor: 띠부씰 응답값 수정

### DIFF
--- a/src/main/java/com/yfive/gbjs/domain/seal/converter/UserSealConverter.java
+++ b/src/main/java/com/yfive/gbjs/domain/seal/converter/UserSealConverter.java
@@ -23,15 +23,17 @@ public class UserSealConverter {
             .spotName(seal.getSpotName())
             .locationName(seal.getLocationName())
             .location(seal.getLocation())
-            .content(seal.getContent())
             .rarity(seal.getRarity())
-            .frontImageUrl(seal.getFrontImageUrl())
-            .backImageUrl(seal.getBackImageUrl())
             .collected(collected)
             .collectedAt(collectedAt);
 
-    if (!collected) {
-      builder.uncollectedImageUrl(seal.getUncollectedImageUrl());
+    if (collected) {
+      builder
+          .content(seal.getContent())
+          .frontImageUrl(seal.getFrontImageUrl())
+          .backImageUrl(seal.getBackImageUrl());
+    } else {
+      builder.frontImageUrl(seal.getUncollectedImageUrl());
     }
 
     return builder.build();
@@ -56,16 +58,18 @@ public class UserSealConverter {
             .spotName(seal.getSpotName())
             .locationName(seal.getLocationName())
             .location(seal.getLocation())
-            .content(seal.getContent())
             .rarity(seal.getRarity())
-            .frontImageUrl(seal.getFrontImageUrl())
-            .backImageUrl(seal.getBackImageUrl())
             .collected(collected)
             .collectedAt(collectedAt)
             .distance(distance);
 
-    if (!collected) {
-      builder.uncollectedImageUrl(seal.getUncollectedImageUrl());
+    if (collected) {
+      builder
+          .content(seal.getContent())
+          .frontImageUrl(seal.getFrontImageUrl())
+          .backImageUrl(seal.getBackImageUrl());
+    } else {
+      builder.frontImageUrl(seal.getUncollectedImageUrl());
     }
     return builder.build();
   }

--- a/src/main/java/com/yfive/gbjs/domain/seal/dto/response/UserSealResponse.java
+++ b/src/main/java/com/yfive/gbjs/domain/seal/dto/response/UserSealResponse.java
@@ -57,9 +57,6 @@ public class UserSealResponse {
 
     @Schema(description = "수집 일시", example = "2025-01-26T10:30:00")
     private LocalDateTime collectedAt;
-
-    @Schema(description = "수집하지 않은 띠부씰 이미지 URL", example = "https://example.com/uncollected.jpg")
-    private String uncollectedImageUrl;
   }
 
   @Builder
@@ -133,9 +130,6 @@ public class UserSealResponse {
 
     @Schema(description = "현재 위치로부터의 거리 (m)", example = "500")
     private Integer distance;
-
-    @Schema(description = "수집하지 않은 띠부씰 이미지 URL", example = "https://example.com/uncollected.jpg")
-    private String uncollectedImageUrl;
   }
 
   @Builder


### PR DESCRIPTION
uncollectImageUrl -> frontImageUrl로 응답

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 응답 스키마에서 uncollectedImageUrl 필드를 제거(UserSealDTO, NearbySealDTO).
  * 미수집 상태에서는 frontImageUrl에 미수집 이미지 URL을 제공하도록 일관화.
  * 수집된 경우에만 content, frontImageUrl, backImageUrl을 포함하도록 매핑 로직 정리.
  * 공개 메서드 시그니처 변화 없음.
  * 주의: 클라이언트가 uncollectedImageUrl에 의존했다면 frontImageUrl 사용으로 수정 필요.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->